### PR TITLE
Modify mint request structure and add lastMintRequest to the reserve account comment

### DIFF
--- a/internal/tokens/fungible.go
+++ b/internal/tokens/fungible.go
@@ -27,12 +27,14 @@ func FungibleTypeURL(typeId string) string {
 }
 
 type ReserveAccountComment struct {
-	Supply uint64 `json:"supply"`
+	Supply          uint64                     `json:"supply"`
+	LastMintRequest *types.FungibleMintRequest `json:"lastMintRequest,omitempty"`
 }
 
 type ReserveAccountRecord struct {
-	Balance uint64
-	Supply  uint64
+	Balance         uint64
+	Supply          uint64
+	LastMintRequest *types.FungibleMintRequest
 }
 
 type MovementStartPosition struct {
@@ -213,13 +215,17 @@ func (ctx *FungibleTxContext) getReserveAccount() (*ReserveAccountRecord, error)
 	}
 
 	return &ReserveAccountRecord{
-		Balance: record.Balance,
-		Supply:  comment.Supply,
+		Balance:         record.Balance,
+		Supply:          comment.Supply,
+		LastMintRequest: comment.LastMintRequest,
 	}, nil
 }
 
 func (ctx *FungibleTxContext) putReserveAccount(reserve *ReserveAccountRecord) error {
-	serializedComment, err := encodeReserveAccountComment(&ReserveAccountComment{Supply: reserve.Supply})
+	serializedComment, err := encodeReserveAccountComment(&ReserveAccountComment{
+		Supply:          reserve.Supply,
+		LastMintRequest: reserve.LastMintRequest,
+	})
 	if err != nil {
 		return err
 	}

--- a/internal/tokens/manager.go
+++ b/internal/tokens/manager.go
@@ -1311,6 +1311,12 @@ func (m *Manager) FungiblePrepareMint(typeId string, request *types.FungibleMint
 		return nil, err
 	}
 
+	if isAddOverflow64(reserve.Balance, request.Quantity) {
+		return nil, common.NewErrInvalid("Cannot mint due to reserve balance overflow.")
+	}
+	if isAddOverflow64(reserve.Supply, request.Quantity) {
+		return nil, common.NewErrInvalid("Cannot mint due to supply overflow.")
+	}
 	reserve.Balance += request.Quantity
 	reserve.Supply += request.Quantity
 	reserve.LastMintRequest = request
@@ -1430,6 +1436,7 @@ func (m *Manager) FungiblePrepareConsolidate(typeId string, request *types.Fungi
 			return nil, err
 		}
 
+		// This never overflows because the total supply cannot exceed max uint64
 		mainRecord.Balance += accRecord.Balance
 
 		if err = ctx.deleteAccountRecord(accRecord); err != nil {

--- a/internal/tokens/manager.go
+++ b/internal/tokens/manager.go
@@ -1296,8 +1296,8 @@ func (m *Manager) FungibleDescribe(typeId string) (*types.FungibleDescribeRespon
 }
 
 func (m *Manager) FungiblePrepareMint(typeId string, request *types.FungibleMintRequest) (*types.FungibleMintResponse, error) {
-	if request.Supply == 0 {
-		return nil, common.NewErrInvalid("Supply must be a positive integer (supply > 0).")
+	if request.Quantity == 0 {
+		return nil, common.NewErrInvalid("Quantity must be a positive integer (quantity > 0).")
 	}
 
 	ctx, err := newTxContext(m).fungible(typeId)
@@ -1311,8 +1311,9 @@ func (m *Manager) FungiblePrepareMint(typeId string, request *types.FungibleMint
 		return nil, err
 	}
 
-	reserve.Balance += request.Supply
-	reserve.Supply += request.Supply
+	reserve.Balance += request.Quantity
+	reserve.Supply += request.Quantity
+	reserve.LastMintRequest = request
 
 	if err = ctx.putReserveAccount(reserve); err != nil {
 		return nil, err

--- a/internal/tokens/manager_test.go
+++ b/internal/tokens/manager_test.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"math"
 	"net/http"
 	"os"
 	"path"
@@ -1996,6 +1997,33 @@ func TestTokensManager_FungibleMintToken(t *testing.T) {
 		mintRequest := &types.FungibleMintRequest{Quantity: 1}
 		response, err := env.manager.FungiblePrepareMint("a", mintRequest)
 		assertTokenHttpErrMessage(t, http.StatusBadRequest, "invalid type id", response, err)
+	})
+
+	t.Run("error: balance overflow", func(t *testing.T) {
+		mintRequest := &types.FungibleMintRequest{Quantity: math.MaxUint64}
+		response, err := env.manager.FungiblePrepareMint(typeId, mintRequest)
+		assertTokenHttpErrMessage(t, http.StatusBadRequest, "balance overflow", response, err)
+	})
+
+	t.Run("error: supply overflow", func(t *testing.T) {
+		desc, err := env.manager.FungibleDescribe(typeId)
+		require.NoError(t, err)
+
+		transferRequest := &types.FungibleTransferRequest{
+			Owner:    reserveAccountUser,
+			Account:  mainAccount,
+			NewOwner: "bob",
+			Quantity: desc.Supply,
+			Comment:  "tip",
+		}
+		transferResponse, err := env.manager.FungiblePrepareTransfer(typeId, transferRequest)
+		require.NoError(t, err)
+		require.NotNil(t, transferResponse)
+		env.fungibleRequireSignAndSubmit(t, "bob", (*FungibleTransferResponse)(transferResponse))
+
+		mintRequest := &types.FungibleMintRequest{Quantity: math.MaxUint64 - desc.Supply + 1}
+		response, err := env.manager.FungiblePrepareMint(typeId, mintRequest)
+		assertTokenHttpErrMessage(t, http.StatusBadRequest, "supply overflow", response, err)
 	})
 }
 

--- a/internal/tokens/manager_test.go
+++ b/internal/tokens/manager_test.go
@@ -1912,7 +1912,7 @@ func TestTokensManager_FungibleMintToken(t *testing.T) {
 	typeId := response.TypeId
 
 	t.Run("error: wrong signature (before mint)", func(t *testing.T) {
-		mintRequest := &types.FungibleMintRequest{Supply: 5}
+		mintRequest := &types.FungibleMintRequest{Quantity: 5}
 		mintResponse, err := env.manager.FungiblePrepareMint(typeId, mintRequest)
 		require.NoError(t, err)
 		require.NotNil(t, mintResponse)
@@ -1922,7 +1922,7 @@ func TestTokensManager_FungibleMintToken(t *testing.T) {
 	})
 
 	t.Run("error: wrong signer (before mint)", func(t *testing.T) {
-		mintRequest := &types.FungibleMintRequest{Supply: 5}
+		mintRequest := &types.FungibleMintRequest{Quantity: 5}
 		mintResponse, err := env.manager.FungiblePrepareMint(typeId, mintRequest)
 		require.NoError(t, err)
 		require.NotNil(t, mintResponse)
@@ -1932,7 +1932,7 @@ func TestTokensManager_FungibleMintToken(t *testing.T) {
 	})
 
 	t.Run("success: signed by owner", func(t *testing.T) {
-		mintRequest := &types.FungibleMintRequest{Supply: 5}
+		mintRequest := &types.FungibleMintRequest{Quantity: 5}
 		mintResponse, err := env.manager.FungiblePrepareMint(typeId, mintRequest)
 		require.NoError(t, err)
 		require.NotNil(t, mintResponse)
@@ -1946,7 +1946,7 @@ func TestTokensManager_FungibleMintToken(t *testing.T) {
 	})
 
 	t.Run("success: second mint", func(t *testing.T) {
-		mintRequest := &types.FungibleMintRequest{Supply: 5}
+		mintRequest := &types.FungibleMintRequest{Quantity: 5}
 		mintResponse, err := env.manager.FungiblePrepareMint(typeId, mintRequest)
 		require.NoError(t, err)
 		require.NotNil(t, mintResponse)
@@ -1960,7 +1960,7 @@ func TestTokensManager_FungibleMintToken(t *testing.T) {
 	})
 
 	t.Run("error: wrong signature (after mint)", func(t *testing.T) {
-		mintRequest := &types.FungibleMintRequest{Supply: 5}
+		mintRequest := &types.FungibleMintRequest{Quantity: 5}
 		mintResponse, err := env.manager.FungiblePrepareMint(typeId, mintRequest)
 		require.NoError(t, err)
 		require.NotNil(t, mintResponse)
@@ -1970,7 +1970,7 @@ func TestTokensManager_FungibleMintToken(t *testing.T) {
 	})
 
 	t.Run("error: wrong signer (after mint)", func(t *testing.T) {
-		mintRequest := &types.FungibleMintRequest{Supply: 5}
+		mintRequest := &types.FungibleMintRequest{Quantity: 5}
 		mintResponse, err := env.manager.FungiblePrepareMint(typeId, mintRequest)
 		require.NoError(t, err)
 		require.NotNil(t, mintResponse)
@@ -1980,20 +1980,20 @@ func TestTokensManager_FungibleMintToken(t *testing.T) {
 	})
 
 	t.Run("error: zero supply", func(t *testing.T) {
-		mintRequest := &types.FungibleMintRequest{Supply: 0}
+		mintRequest := &types.FungibleMintRequest{Quantity: 0}
 		mintResponse, err := env.manager.FungiblePrepareMint(typeId, mintRequest)
 		assertTokenHttpErrMessage(t, http.StatusBadRequest, "must be a positive", mintResponse, err)
 	})
 
 	t.Run("error: type does not exists", func(t *testing.T) {
-		mintRequest := &types.FungibleMintRequest{Supply: 1}
+		mintRequest := &types.FungibleMintRequest{Quantity: 1}
 		tokenTypeIDBase64, _ := NameToID("FakeToken")
 		response, err := env.manager.FungiblePrepareMint(tokenTypeIDBase64, mintRequest)
 		assertTokenHttpErrMessage(t, http.StatusNotFound, "db '.*' doesn't exist", response, err)
 	})
 
 	t.Run("error: invalid type", func(t *testing.T) {
-		mintRequest := &types.FungibleMintRequest{Supply: 1}
+		mintRequest := &types.FungibleMintRequest{Quantity: 1}
 		response, err := env.manager.FungiblePrepareMint("a", mintRequest)
 		assertTokenHttpErrMessage(t, http.StatusBadRequest, "invalid type id", response, err)
 	})
@@ -2006,7 +2006,7 @@ func TestTokensManager_FungibleTransferToken(t *testing.T) {
 	require.NoError(t, err)
 	typeId := deployResponse.TypeId
 
-	mintRequest := &types.FungibleMintRequest{Supply: 10}
+	mintRequest := &types.FungibleMintRequest{Quantity: 10}
 	mintResponse, err := env.manager.FungiblePrepareMint(typeId, mintRequest)
 	require.NoError(t, err)
 	require.NotNil(t, mintResponse)
@@ -2319,7 +2319,7 @@ func TestTokensManager_FungibleConsolidateToken(t *testing.T) {
 
 	env.updateUsers(t)
 
-	mintResponse, err := env.manager.FungiblePrepareMint(typeId, &types.FungibleMintRequest{Supply: 100})
+	mintResponse, err := env.manager.FungiblePrepareMint(typeId, &types.FungibleMintRequest{Quantity: 100})
 	require.NoError(t, err)
 	require.NotNil(t, mintResponse)
 
@@ -2591,7 +2591,7 @@ func TestTokensManager_FungibleMovements(t *testing.T) {
 	typeId := deployResponse.TypeId
 	env.updateUsers(t)
 
-	mintResponse, err := env.manager.FungiblePrepareMint(typeId, &types.FungibleMintRequest{Supply: 100_000})
+	mintResponse, err := env.manager.FungiblePrepareMint(typeId, &types.FungibleMintRequest{Quantity: 100_000})
 	require.NoError(t, err)
 	require.NotNil(t, mintResponse)
 	env.fungibleRequireSignAndSubmit(t, "bob", (*FungibleMintResponse)(mintResponse))
@@ -2913,7 +2913,7 @@ func newOfferTestEnv(t *testing.T) *offerTestEnv {
 
 	env.updateUsers(t)
 
-	fungMintResp, err := env.manager.FungiblePrepareMint(env.typeIds["fung"], &types.FungibleMintRequest{Supply: 1_000_000})
+	fungMintResp, err := env.manager.FungiblePrepareMint(env.typeIds["fung"], &types.FungibleMintRequest{Quantity: 1_000_000})
 	require.NoError(t, err, "failed to mint: fungible")
 	env.fungibleRequireSignAndSubmit(t, "bob", (*FungibleMintResponse)(fungMintResp))
 

--- a/internal/tokens/utils.go
+++ b/internal/tokens/utils.go
@@ -6,6 +6,7 @@ package tokens
 import (
 	"crypto"
 	"encoding/base64"
+	"math"
 	"net/http"
 	"regexp"
 	"strings"
@@ -108,6 +109,10 @@ func convertErrorType(err error) error {
 	default:
 		return err
 	}
+}
+
+func isAddOverflow64(a, b uint64) bool {
+	return a > math.MaxUint64-b
 }
 
 // ====================================================

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -802,7 +802,7 @@ func TestTokensServer(t *testing.T) {
 
 		supply := uint64(5)
 		t.Run("mint", func(t *testing.T) {
-			mintReq := types.FungibleMintRequest{Supply: supply}
+			mintReq := types.FungibleMintRequest{Quantity: supply}
 			mintResp := tokens.FungibleMintResponse{}
 			env.testPostSignAndSubmit(t,
 				common.URLForType(constants.FungibleMint, typeId),

--- a/pkg/types/http.go
+++ b/pkg/types/http.go
@@ -160,100 +160,101 @@ type AnnotationRecord struct {
 // ====================================================
 
 type FungibleDeployRequest struct {
-	Name         string `json:"name"`
-	Description  string `json:"description"`
-	ReserveOwner string `json:"reserveOwner"`
+	Name         string `json:"name"`         // the name of the token (unique)
+	Description  string `json:"description"`  // a free form description of the token
+	ReserveOwner string `json:"reserveOwner"` // the owner (user ID) of the reserve account
 }
 
 type FungibleDeployResponse struct {
-	TypeId       string `json:"typeId"`
-	Name         string `json:"name"`
-	Description  string `json:"description"`
-	Supply       uint64 `json:"supply"`
-	ReserveOwner string `json:"reserveOwner"`
-	Url          string `json:"url"`
+	TypeId       string `json:"typeId"`       // the unique ID of the token
+	Name         string `json:"name"`         // the name of the token
+	Description  string `json:"description"`  // a free form description of the token
+	Supply       uint64 `json:"supply"`       // the current supply of the token
+	ReserveOwner string `json:"reserveOwner"` // the owner (user ID) of the reserve account
+	Url          string `json:"url"`          // the token address
 }
 
 type FungibleDescribeResponse FungibleDeployResponse
 
 type FungibleMintRequest struct {
-	Supply uint64 `json:"supply"`
+	Quantity uint64 `json:"quantity"` // the quantity of tokens added to the supply
+	Comment  string `json:"comment"`  // a free form description of the operation
 }
 
 type FungibleMintResponse struct {
-	TypeId        string `json:"typeId"`
-	TxEnvelope    string `json:"txEnvelope"`    //base64 (std, padded) encoding of bytes
-	TxPayloadHash string `json:"txPayloadHash"` //base64 (std, padded) encoding of bytes
+	TypeId        string `json:"typeId"`        // the unique ID of the token
+	TxEnvelope    string `json:"txEnvelope"`    // base64 (std, padded) encoding of bytes
+	TxPayloadHash string `json:"txPayloadHash"` // base64 (std, padded) encoding of bytes
 }
 
 type FungibleTransferRequest struct {
-	Owner    string `json:"owner"`
-	Account  string `json:"account"`
-	NewOwner string `json:"newOwner"`
-	Quantity uint64 `json:"quantity"`
-	Comment  string `json:"comment"`
+	Owner    string `json:"owner"`    // the owner of the source account
+	Account  string `json:"account"`  // the source account
+	NewOwner string `json:"newOwner"` // the transfer destination user ID
+	Quantity uint64 `json:"quantity"` // the quantity of tokens to transfer
+	Comment  string `json:"comment"`  // a free form description of the operation
 }
 
 type FungibleTransferResponse struct {
-	TypeId        string `json:"typeId"`
-	Owner         string `json:"owner"`
-	Account       string `json:"account"`
-	NewOwner      string `json:"newOwner"`
-	NewAccount    string `json:"newAccount"`
-	TxEnvelope    string `json:"txEnvelope"`    //base64 (std, padded) encoding of bytes
-	TxPayloadHash string `json:"txPayloadHash"` //base64 (std, padded) encoding of bytes
+	TypeId        string `json:"typeId"`        // the unique ID of the token
+	Owner         string `json:"owner"`         // the owner of the source account
+	Account       string `json:"account"`       // the source account
+	NewOwner      string `json:"newOwner"`      // the transfer destination user ID
+	NewAccount    string `json:"newAccount"`    // the transfer destination account ID
+	TxEnvelope    string `json:"txEnvelope"`    // base64 (std, padded) encoding of bytes
+	TxPayloadHash string `json:"txPayloadHash"` // base64 (std, padded) encoding of bytes
 }
 
 type FungibleConsolidateRequest struct {
-	Owner    string   `json:"owner"`
-	Accounts []string `json:"accounts"`
+	Owner    string   `json:"owner"`    // the owner of the account(s)
+	Accounts []string `json:"accounts"` // the account IDs to consolidate
 }
 
 type FungibleConsolidateResponse struct {
-	TypeId        string `json:"typeId"`
-	Owner         string `json:"owner"`
-	TxEnvelope    string `json:"txEnvelope"`    //base64 (std, padded) encoding of bytes
-	TxPayloadHash string `json:"txPayloadHash"` //base64 (std, padded) encoding of bytes
+	TypeId        string `json:"typeId"`        // the unique ID of the token
+	Owner         string `json:"owner"`         // the owner of the account(s)
+	TxEnvelope    string `json:"txEnvelope"`    // base64 (std, padded) encoding of bytes
+	TxPayloadHash string `json:"txPayloadHash"` // base64 (std, padded) encoding of bytes
 }
 
 type FungibleSubmitRequest struct {
-	TypeId        string `json:"typeId"`
-	TxEnvelope    string `json:"txEnvelope"`    //base64 (std, padded) encoding of bytes
-	TxPayloadHash string `json:"txPayloadHash"` //base64 (std, padded) encoding of bytes
-	Signer        string `json:"signer"`
-	Signature     string `json:"signature"` //base64 (std, padded) encoding of bytes
+	TypeId        string `json:"typeId"`        // the unique ID of the token
+	TxEnvelope    string `json:"txEnvelope"`    // base64 (std, padded) encoding of bytes
+	TxPayloadHash string `json:"txPayloadHash"` // base64 (std, padded) encoding of bytes
+	Signer        string `json:"signer"`        // the signers of the operation
+	Signature     string `json:"signature"`     // base64 (std, padded) encoding of bytes
 }
 
 type FungibleSubmitResponse struct {
-	TypeId    string `json:"typeId"`
-	TxId      string `json:"txId"`
-	TxReceipt string `json:"txReceipt"`
+	TypeId    string `json:"typeId"`    // the unique ID of the token
+	TxId      string `json:"txId"`      // the transaction ID
+	TxReceipt string `json:"txReceipt"` // the transaction receipt
 }
 
 type FungibleAccountRecord struct {
-	Account string `json:"account"`
-	Owner   string `json:"owner"`
-	Balance uint64 `json:"balance"`
-	Comment string `json:"comment"`
+	Account string `json:"account"` // the account ID (main or TX ID)
+	Owner   string `json:"owner"`   // the owner of the account (user ID)
+	Balance uint64 `json:"balance"` // the account's balance
+	Comment string `json:"comment"` // a free form description of the account ("main" or the transfer's description)
 }
 
 type TxVersion struct {
-	BlockNum uint64 `json:"blockNum,omitempty"`
-	TxNum    uint64 `json:"txNum,omitempty"`
+	BlockNum uint64 `json:"blockNum"` // the block to which an operation was inserted
+	TxNum    uint64 `json:"txNum"`    // the TX index in the block
 }
 
 type FungibleIncomingTxAccountRecord struct {
 	Version     TxVersion `json:"version"`     // the tx account version for this movement
 	Account     string    `json:"account"`     // the tx account ID
 	Quantity    uint64    `json:"quantity"`    // the tx account balance
-	Comment     string    `json:"comment"`     // the tx account comment
+	Comment     string    `json:"comment"`     // a free form description of the operation (the transfer's description)
 	SourceOwner string    `json:"sourceOwner"` // the user ID that transferred the fungible tokens
 }
 
 type FungibleOutgoingTxAccountRecord struct {
 	Account  string `json:"account"`  // the tx account ID
 	Quantity uint64 `json:"quantity"` // the tx account balance
-	Comment  string `json:"comment"`  // the tx account comment
+	Comment  string `json:"comment"`  // a free form description of the operation (the transfer's description)
 }
 
 type FungibleMovementRecord struct {


### PR DESCRIPTION
- Add docs to all fungible HTTP requests
- Change mint request: supply->quantity and add comment
- Remove `omitempty` from the version struct
- Add `lastMintRequest` to the reserve account comment

Signed-off-by: Liran Funaro <liran.funaro@gmail.com>